### PR TITLE
Expand config

### DIFF
--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -7,7 +7,6 @@ jest.mock('read-pkg-up', () => {
     mockPDJ
   }
 })
-const readPkgUp = require('read-pkg-up')
 
 describe('config.js', () => {
   let mockCommander
@@ -34,10 +33,26 @@ describe('config.js', () => {
       }
     ])
   })
-  it('uses package.json setting for "bundlesize" second', () => {
-    mockCommander.files = null
-    jest.doMock('commander', () => mockCommander)
-    const config = require('../config')
-    expect(config.files).toMatchObject(readPkgUp.mockPDJ.bundlesize)
+  describe('when cli options are absent', () => {
+    beforeEach(() => {
+      mockCommander.files = null
+    })
+    it('uses package.json setting for "bundlesize"', () => {
+      jest.doMock('commander', () => mockCommander)
+      const readPkgUp = require('read-pkg-up')
+      const config = require('../config')
+      expect(config.files).toMatchObject(readPkgUp.mockPDJ.bundlesize)
+    })
+    it('permits key-value config in package.json', () => {
+      jest.doMock('commander', () => mockCommander)
+      const readPkgUp = require('read-pkg-up')
+      const files = [{ path: 'new.js', maxSize: '50MB' }]
+      readPkgUp.mockPDJ.bundlesize = {
+        files: files,
+        other: 'something new'
+      }
+      const config = require('../config')
+      expect(config.files).toMatchObject(files)
+    })
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -40,8 +40,24 @@ if (!packageJSONconfig && !cliConfig) {
   )
 }
 
-const config = {
-  files: cliConfig || packageJSONconfig
+const defaultConfig = {
+  files: []
+}
+let config
+if (cliConfig) {
+  config = {
+    files: cliConfig
+  }
+} else if (Array.isArray(packageJSONconfig)) {
+  config = {
+    ...defaultConfig,
+    files: packageJSONconfig
+  }
+} else {
+  config = {
+    ...defaultConfig,
+    ...(packageJSONconfig || {})
+  }
 }
 
 debug('cli config', cliConfig)


### PR DESCRIPTION
Add new config format that allows specifying an object map with key files.
Maintain legacy behavior by checking for an `Array`